### PR TITLE
fix(path_generator): apply clang-tidy

### DIFF
--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -314,9 +314,10 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
 
     for (auto [it, goal_arc_length] = std::make_tuple(lanelets.begin(), 0.); it != lanelets.end();
          ++it) {
+      const auto id = it->id();  // capture the necessary value outside the lambda
       if (std::any_of(
             planner_data_.goal_lanelets.begin(), planner_data_.goal_lanelets.end(),
-            [&](const auto & goal_lanelet) { return it->id() == goal_lanelet.id(); })) {
+            [&](const auto & goal_lanelet) { return id == goal_lanelet.id(); })) {
         goal_arc_length += lanelet::utils::getArcCoordinates({*it}, planner_data_.goal_pose).length;
         s_end = std::min(s_end, goal_arc_length);
         break;


### PR DESCRIPTION
## Description

This PR fixes a Clang-Tidy error related to capturing a loop variable (`it`) by reference in a lambda expression. The original implementation attempted to reference `it` within a lambda used inside `std::any_of`, which is not allowed as `it` is a local binding declared in the enclosing scope.
The fix moves the required value (`id`) out of the lambda, eliminating the invalid reference capture.

## Related Links

- https://github.com/autowarefoundation/autoware_core/pull/586

## How Was This PR Tested?

Tested in this workflow:
- https://github.com/autowarefoundation/autoware_core/actions/runs/16588843580/job/46919791907?pr=588

## Effects on System Behavior

This is a non-functional fix that improves code correctness and resolves static analysis errors.