### PR TITLE
refactor(behavior_velocity_stop_line_module): avoid using PathWithLaneId after conversion to Trajectory

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -81,7 +81,7 @@ public:
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface> &
       planning_factor_interface);
 
-  bool modifyPathVelocity(PathWithLaneId * path) override;
+  bool modifyPathVelocity(PathWithLaneId * _path) override;
 
   /**
    * @brief Calculate ego position and stop point.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -91,7 +91,8 @@ public:
    * @return Pair of ego position and optional stop point.
    */
   std::pair<double, std::optional<double>> getEgoAndStopPoint(
-    const Trajectory & trajectory, const PathWithLaneId & path,
+    const Trajectory & trajectory, const std::vector<geometry_msgs::msg::Point> & left_bound,
+    const std::vector<geometry_msgs::msg::Point> & right_bound,
     const geometry_msgs::msg::Pose & ego_pose, const State & state) const;
 
   /**

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp
@@ -120,8 +120,8 @@ TEST_F(StopLineModuleTest, TestGetEgoAndStopPoint)
 
   {  // Test for APPROACH state
     // Execute the function
-    const auto [ego_s, stop_point_s] =
-      module_->getEgoAndStopPoint(trajectory_, path_, ego_pose, StopLineModule::State::APPROACH);
+    const auto [ego_s, stop_point_s] = module_->getEgoAndStopPoint(
+      trajectory_, path_.left_bound, path_.right_bound, ego_pose, StopLineModule::State::APPROACH);
 
     // Verify results
     EXPECT_DOUBLE_EQ(ego_s, 5.0);
@@ -129,8 +129,8 @@ TEST_F(StopLineModuleTest, TestGetEgoAndStopPoint)
   }
 
   {  // Test for STOPPED state
-    const auto [ego_s, stop_point_s] =
-      module_->getEgoAndStopPoint(trajectory_, path_, ego_pose, StopLineModule::State::STOPPED);
+    const auto [ego_s, stop_point_s] = module_->getEgoAndStopPoint(
+      trajectory_, path_.left_bound, path_.right_bound, ego_pose, StopLineModule::State::STOPPED);
 
     EXPECT_TRUE(stop_point_s.has_value());
     EXPECT_DOUBLE_EQ(ego_s, 5.0);


### PR DESCRIPTION
## Description

Currently `PathWithLaneId` is still used to retrieve left/right bound data in `getEgoAndStopPoint()`. To avoid this, path bounds are passed directly to `getEgoAndStopPoint()`.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
