### PR TITLE
fix(behavior_velocity_planner): set header to module input

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -135,7 +135,8 @@ private:
   // function
   bool isDataReady(rclcpp::Clock clock);
   Trajectory generatePath(
-    const Trajectory & input_path, const std::vector<geometry_msgs::msg::Point> & left_bound,
+    const Trajectory & input_path, const std_msgs::msg::Header & header,
+    const std::vector<geometry_msgs::msg::Point> & left_bound,
     const std::vector<geometry_msgs::msg::Point> & right_bound, const PlannerData & planner_data);
 
   std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
@@ -51,7 +51,7 @@ public:
   // cppcheck-suppress functionConst
   Trajectory planPathVelocity(
     const PlannerData & planner_data, const Trajectory & input_path,
-    const std::vector<geometry_msgs::msg::Point> & left_bound,
+    const std_msgs::msg::Header & header, const std::vector<geometry_msgs::msg::Point> & left_bound,
     const std::vector<geometry_msgs::msg::Point> & right_bound);
 
   RequiredSubscriptionInfo getRequiredSubscriptions() const { return required_subscriptions_; }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -317,7 +317,8 @@ void BehaviorVelocityPlannerNode::onTrigger(
   }
 
   const auto output_path = generatePath(
-    *input_path, input_path_msg->left_bound, input_path_msg->right_bound, planner_data_);
+    *input_path, input_path_msg->header, input_path_msg->left_bound, input_path_msg->right_bound,
+    planner_data_);
 
   autoware_planning_msgs::msg::Path output_path_msg;
   output_path_msg.header.frame_id = "map";
@@ -341,7 +342,8 @@ void BehaviorVelocityPlannerNode::onTrigger(
 }
 
 Trajectory BehaviorVelocityPlannerNode::generatePath(
-  const Trajectory & input_path, const std::vector<geometry_msgs::msg::Point> & left_bound,
+  const Trajectory & input_path, const std_msgs::msg::Header & header,
+  const std::vector<geometry_msgs::msg::Point> & left_bound,
   const std::vector<geometry_msgs::msg::Point> & right_bound, const PlannerData & planner_data)
 {
   // TODO(someone): support backward path
@@ -356,7 +358,7 @@ Trajectory BehaviorVelocityPlannerNode::generatePath(
 
   // Plan path velocity
   const auto velocity_planned_path =
-    planner_manager_.planPathVelocity(planner_data, input_path, left_bound, right_bound);
+    planner_manager_.planPathVelocity(planner_data, input_path, header, left_bound, right_bound);
 
   // check stop point
   const auto stop_intervals = experimental::trajectory::find_intervals(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
@@ -79,10 +79,11 @@ void BehaviorVelocityPlannerManager::removeScenePlugin(
 
 Trajectory BehaviorVelocityPlannerManager::planPathVelocity(
   const PlannerData & planner_data, const Trajectory & input_path,
-  const std::vector<geometry_msgs::msg::Point> & left_bound,
+  const std_msgs::msg::Header & header, const std::vector<geometry_msgs::msg::Point> & left_bound,
   const std::vector<geometry_msgs::msg::Point> & right_bound)
 {
   autoware_internal_planning_msgs::msg::PathWithLaneId input_path_msg;
+  input_path_msg.header = header;
   input_path_msg.points = input_path.restore();
   input_path_msg.left_bound = left_bound;
   input_path_msg.right_bound = right_bound;
@@ -90,7 +91,8 @@ Trajectory BehaviorVelocityPlannerManager::planPathVelocity(
   auto output_path_msg = input_path_msg;
 
   for (const auto & plugin : scene_manager_plugins_) {
-    plugin->updateSceneModuleInstances(std::make_shared<PlannerData>(planner_data), input_path_msg);
+    plugin->updateSceneModuleInstances(
+      std::make_shared<const PlannerData>(planner_data), input_path_msg);
     plugin->plan(&output_path_msg);
   }
 


### PR DESCRIPTION
## Description

Copy the header of the original `PathWithLaneId` to the input of scene manager plugins with RTC.
A timestamp is required to be set for `updateRTCStatus()` in `TrafficLightModuleManager::launchNewModules()`.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
